### PR TITLE
Remove dead links from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # WordNet Angular
 
-Princeton WordNet Interface based on Angular.js and Rust, this is currently used to run three websites:
-
-https://polylingwn.linguistic-lod.org/
-
-http://wordnet-rdf.princeton.edu
+Princeton WordNet Interface based on Angular.js and Rust, this is currently used to run the following websites:
 
 https://en-word.net/
 


### PR DESCRIPTION
Two of the linked to websites don't appear to be running anymore. This commits removes them for now and replaces the wording to omit a specific number.